### PR TITLE
Reduce initial window height to 800 to avoid opening too tall

### DIFF
--- a/ModbusTerm/MainWindow.xaml
+++ b/ModbusTerm/MainWindow.xaml
@@ -9,8 +9,8 @@
         xmlns:helpers="clr-namespace:ModbusTerm.Helpers"
         xmlns:viewmodels="clr-namespace:ModbusTerm.ViewModels"
         mc:Ignorable="d"
-        Title="Modbus Toolbox - Modbus Develpment Tools" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
-        Width="900" Height="950" MinWidth="800" MinHeight="800"
+        Title="Modbus Toolbox - Modbus Development Tools" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+        Width="900" Height="800" MinWidth="800" MinHeight="800"
         WindowStartupLocation="CenterScreen">
     
     <Window.Resources>


### PR DESCRIPTION
This PR reduces the initial `Height` in `MainWindow.xaml` so the main window opens shorter by default while keeping `MinHeight = 800`.

- Initial Height: 800 (down from 950)
- MinHeight: 800 (unchanged)

Fixes #1
